### PR TITLE
feat: add lock-safe Stats() snapshot API with tests and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ The format is based on https://keepachangelog.com/en/1.1.0/, and this project fo
 - Package-level docs and example for `pkg.go.dev`.
 - Baseline benchmark suite for schedule, reschedule, cancel, and shutdown paths.
 - README benchmark section with run command and sample output.
+- `Stats()` snapshot API with pending/running/closed state.
 
 ### Changed
 - Safer cleanup semantics for rescheduled tasks (`deleteIfCurrent`).
 - Cancellation-aware `StrategyBlock` acquire path.
+- Improved `OnExecuted` timing accuracy by measuring task duration before internal cleanup.
 - README clarity and structure improvements.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - **Debouncing by ID**: Scheduling the same ID replaces the previous task.
 - **Concurrency Limits**: Choose blocking or dropping behavior when at capacity.
 - **Graceful Shutdown**: Cancel timers and wait for active tasks to finish.
+- **Runtime Stats**: Read pending/running/closed state via `Stats()`.
 - **Pluggable Telemetry**: Attach your own metrics/logging hooks.
 
 ## Installation
@@ -95,6 +96,13 @@ defer cancel()
 if err := mgr.Shutdown(ctx); err != nil {
     log.Printf("shutdown timed out: %v", err)
 }
+```
+
+### Runtime Stats
+
+```go
+s := mgr.Stats()
+log.Printf("pending=%d running=%d closed=%t", s.Pending, s.Running, s.Closed)
 ```
 
 ## Benchmarks

--- a/pending.go
+++ b/pending.go
@@ -15,11 +15,22 @@ var ErrTaskDropped = errors.New("pending: task dropped due to concurrency limit"
 // The provided context is cancelled if the manager shuts down or the task is replaced.
 type Task func(ctx context.Context)
 
+// Stats is a point-in-time snapshot of manager state.
+type Stats struct {
+	// Pending is the number of scheduled tasks that are not currently executing.
+	Pending int
+	// Running is the number of tasks currently executing.
+	Running int
+	// Closed reports whether the manager has been shut down.
+	Closed bool
+}
+
 // Manager coordinates the lifecycle of delayed tasks, ensuring thread-safety
 // and providing concurrency control via semaphores.
 type Manager struct {
 	mu      sync.RWMutex
 	pending map[string]*entry
+	running int
 
 	semaphore chan struct{}
 	strategy  Strategy
@@ -90,16 +101,36 @@ func (m *Manager) Schedule(id string, d time.Duration, task Task) {
 				return
 			}
 			defer m.releaseSlot()
+			m.updateRunning(1)
+			defer m.updateRunning(-1)
 
 			start := time.Now()
 			task(ctx)
+			duration := time.Since(start)
 
 			m.deleteIfCurrent(id, e)
-			m.logger.OnExecuted(id, time.Since(start))
+			m.logger.OnExecuted(id, duration)
 		})
 	})
 
 	m.pending[id] = e
+}
+
+// Stats returns a lock-safe snapshot of manager state.
+func (m *Manager) Stats() Stats {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	pending := len(m.pending) - m.running
+	if pending < 0 {
+		pending = 0
+	}
+
+	return Stats{
+		Pending: pending,
+		Running: m.running,
+		Closed:  m.isClosed,
+	}
 }
 
 func (m *Manager) acquireSlot(ctx context.Context, id string, e *entry) bool {
@@ -132,6 +163,12 @@ func (m *Manager) releaseSlot() {
 	if m.semaphore != nil {
 		<-m.semaphore
 	}
+}
+
+func (m *Manager) updateRunning(delta int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.running += delta
 }
 
 func (m *Manager) deleteIfCurrent(id string, target *entry) {

--- a/pending_test.go
+++ b/pending_test.go
@@ -249,6 +249,146 @@ func TestManager_ScheduleAfterShutdownIsNoOp(t *testing.T) {
 	}
 }
 
+func TestManager_StatsSnapshotLifecycle(t *testing.T) {
+	mgr := NewManager()
+
+	s := mgr.Stats()
+	if s.Pending != 0 || s.Running != 0 || s.Closed {
+		t.Fatalf("unexpected initial stats: %+v", s)
+	}
+
+	mgr.Schedule("stats-pending", time.Hour, func(ctx context.Context) {})
+	s = mgr.Stats()
+	if s.Pending != 1 || s.Running != 0 || s.Closed {
+		t.Fatalf("unexpected stats after schedule: %+v", s)
+	}
+
+	mgr.Cancel("stats-pending")
+	s = mgr.Stats()
+	if s.Pending != 0 || s.Running != 0 || s.Closed {
+		t.Fatalf("unexpected stats after cancel: %+v", s)
+	}
+
+	if err := mgr.Shutdown(context.Background()); err != nil {
+		t.Fatalf("shutdown failed: %v", err)
+	}
+
+	s = mgr.Stats()
+	if s.Pending != 0 || s.Running != 0 || !s.Closed {
+		t.Fatalf("unexpected stats after shutdown: %+v", s)
+	}
+}
+
+func TestManager_StatsPendingAndRunning(t *testing.T) {
+	mgr := NewManager(WithLimit(1, StrategyBlock))
+
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondStarted := make(chan struct{})
+	secondDone := make(chan struct{})
+
+	mgr.Schedule("stats-running", 0, func(ctx context.Context) {
+		close(firstStarted)
+		<-releaseFirst
+	})
+	<-firstStarted
+
+	mgr.Schedule("stats-waiting", 0, func(ctx context.Context) {
+		close(secondStarted)
+		close(secondDone)
+	})
+
+	waitFor(t, 200*time.Millisecond, func() bool {
+		s := mgr.Stats()
+		return s.Running == 1 && s.Pending == 1 && !s.Closed
+	}, "expected one running and one pending task")
+
+	select {
+	case <-secondStarted:
+		t.Fatal("waiting task should not start while first task holds the slot")
+	default:
+	}
+
+	close(releaseFirst)
+
+	select {
+	case <-secondDone:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for second task to complete")
+	}
+
+	waitFor(t, 200*time.Millisecond, func() bool {
+		s := mgr.Stats()
+		return s.Running == 0 && s.Pending == 0
+	}, "expected no running or pending tasks")
+}
+
+func TestManager_StatsConcurrentAccess(t *testing.T) {
+	mgr := NewManager()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var readers sync.WaitGroup
+	errs := make(chan error, 1)
+	for i := 0; i < 4; i++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+
+				s := mgr.Stats()
+				if s.Pending < 0 || s.Running < 0 {
+					select {
+					case errs <- fmt.Errorf("invalid stats: %+v", s):
+					default:
+					}
+					return
+				}
+			}
+		}()
+	}
+
+	for i := 0; i < 200; i++ {
+		id := fmt.Sprintf("stats-concurrent-%d", i)
+		mgr.Schedule(id, time.Hour, func(ctx context.Context) {})
+		mgr.Cancel(id)
+	}
+
+	cancel()
+	readers.Wait()
+
+	select {
+	case err := <-errs:
+		t.Fatal(err)
+	default:
+	}
+}
+
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool, msg string) {
+	t.Helper()
+
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(1 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if cond() {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal(msg)
+		case <-ticker.C:
+		}
+	}
+}
+
 func TestCoverageBooster(t *testing.T) {
 	_ = NewManager(
 		WithLimit(1, StrategyBlock),


### PR DESCRIPTION
## Summary

Adds a minimal runtime stats snapshot API to `pending` via `Manager.Stats()`.

## What’s included

### API
- New exported `Stats` struct:
  - `Pending int`
  - `Running int`
  - `Closed bool`
- New exported method:
  - `func (m *Manager) Stats() Stats`

### Implementation
- Tracks currently executing tasks with an internal `running` counter.
- Updates `running` around actual task execution.
- `Stats()` returns a lock-safe point-in-time snapshot.
- `Pending` is computed as `len(pending) - running` (clamped at 0).

### Tests
- `TestManager_StatsSnapshotLifecycle`
- `TestManager_StatsPendingAndRunning`
- `TestManager_StatsConcurrentAccess`

### Docs
- README:
  - feature list mentions runtime stats
  - added `Runtime Stats` usage snippet
- CHANGELOG:
  - added `Stats()` entry under `Unreleased`

## Validation

- `gofmt -w pending.go pending_test.go`
- `go test ./...`
- `go test -race ./...`

All passed locally.

## Notes

- Backward compatible additive feature.
- No external dependencies added.
