### PR TITLE
chore: cut changelog for v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on https://keepachangelog.com/en/1.1.0/, and this project fo
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-03-03
+
 ### Added
 - Public sentinel error `ErrTaskDropped` for telemetry classification.
 - Package-level docs and example for `pkg.go.dev`.


### PR DESCRIPTION
## Summary

Prepares release notes in `CHANGELOG.md` for `v0.1.1` by moving current unreleased items into a dated release section.

## Changes

- Added `## [0.1.1] - 2026-03-03`
- Kept entries for:
  - `Stats()` snapshot API (`Pending`/`Running`/`Closed`)
  - `OnExecuted` timing accuracy improvement
  - test hardening and benchmark/docs updates
