### PR TITLE
test: add coverage for Stats pending clamp branch

### DIFF
--- a/pending_test.go
+++ b/pending_test.go
@@ -323,6 +323,42 @@ func TestManager_StatsPendingAndRunning(t *testing.T) {
 	}, "expected no running or pending tasks")
 }
 
+func TestManager_StatsPendingClampWhenCanceledWhileRunning(t *testing.T) {
+	mgr := NewManager()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan struct{})
+
+	mgr.Schedule("stats-clamp", 0, func(ctx context.Context) {
+		close(started)
+		<-release
+		close(done)
+	})
+
+	<-started
+	mgr.Cancel("stats-clamp")
+
+	s := mgr.Stats()
+	if s.Running != 1 {
+		t.Fatalf("expected one running task after cancel, got %+v", s)
+	}
+	if s.Pending != 0 {
+		t.Fatalf("expected pending to clamp to zero, got %+v", s)
+	}
+
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for running task to finish")
+	}
+
+	if err := mgr.Shutdown(context.Background()); err != nil {
+		t.Fatalf("shutdown failed: %v", err)
+	}
+}
+
 func TestManager_StatsConcurrentAccess(t *testing.T) {
 	mgr := NewManager()
 


### PR DESCRIPTION
## Summary

Adds a focused test for the `Stats()` pending clamp path (`if pending < 0 { pending = 0 }`).

## What changed

- Added `TestManager_StatsPendingClampWhenCanceledWhileRunning`:
  - schedules a zero-delay task
  - waits for task start
  - cancels task while it is still running (removes map entry)
  - verifies `Stats()` reports:
    - `Running == 1`
    - `Pending == 0` (clamped, not negative)
  - releases task and verifies clean shutdown

## Why

Coverage dropped after introducing the clamp branch in `Stats()`.  
This test validates the intended edge-case behavior and restores branch coverage.

## Validation

- `go test ./...`
- `go test -race ./...`