### PR TITLE
feat: replace Stats.Closed with lifecycle Status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on https://keepachangelog.com/en/1.1.0/, and this project fo
 
 ## [Unreleased]
 
+### Added
+- Manager lifecycle `Status` model with `StatusAccepting`, `StatusDraining`, and `StatusClosed`.
+
+### Changed
+- `Stats()` now reports `Status` instead of `Closed` (breaking API change).
+- Shutdown state transitions are now explicit: `Accepting -> Draining -> Closed`.
+
 ## [0.1.1] - 2026-03-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - **Debouncing by ID**: Scheduling the same ID replaces the previous task.
 - **Concurrency Limits**: Choose blocking or dropping behavior when at capacity.
 - **Graceful Shutdown**: Cancel timers and wait for active tasks to finish.
-- **Runtime Stats**: Read pending/running/closed state via `Stats()`.
+- **Runtime Stats**: Read pending/running/status state via `Stats()`.
 - **Pluggable Telemetry**: Attach your own metrics/logging hooks.
 
 ## Installation
@@ -102,7 +102,7 @@ if err := mgr.Shutdown(ctx); err != nil {
 
 ```go
 s := mgr.Stats()
-log.Printf("pending=%d running=%d closed=%t", s.Pending, s.Running, s.Closed)
+log.Printf("pending=%d running=%d status=%s", s.Pending, s.Running, s.Status)
 ```
 
 ## Benchmarks

--- a/pending.go
+++ b/pending.go
@@ -11,9 +11,30 @@ import (
 // rejects a task because no concurrency slot is available.
 var ErrTaskDropped = errors.New("pending: task dropped due to concurrency limit")
 
-// Task defines the function signature for a scheduled action.
-// The provided context is cancelled if the manager shuts down or the task is replaced.
-type Task func(ctx context.Context)
+// Status represents the current lifecycle state of a Manager.
+type Status int
+
+const (
+	// StatusAccepting means the manager accepts new schedules.
+	StatusAccepting Status = iota
+	// StatusDraining means shutdown has started and running tasks are draining.
+	StatusDraining
+	// StatusClosed means shutdown has completed.
+	StatusClosed
+)
+
+func (s Status) String() string {
+	switch s {
+	case StatusAccepting:
+		return "accepting"
+	case StatusDraining:
+		return "draining"
+	case StatusClosed:
+		return "closed"
+	default:
+		return "unknown"
+	}
+}
 
 // Stats is a point-in-time snapshot of manager state.
 type Stats struct {
@@ -21,9 +42,13 @@ type Stats struct {
 	Pending int
 	// Running is the number of tasks currently executing.
 	Running int
-	// Closed reports whether the manager has been shut down.
-	Closed bool
+	// Status indicates whether the manager is accepting new tasks, draining existing ones, or fully closed.
+	Status Status
 }
+
+// Task defines the function signature for a scheduled action.
+// The provided context is cancelled if the manager shuts down or the task is replaced.
+type Task func(ctx context.Context)
 
 // Manager coordinates the lifecycle of delayed tasks, ensuring thread-safety
 // and providing concurrency control via semaphores.
@@ -31,13 +56,13 @@ type Manager struct {
 	mu      sync.RWMutex
 	pending map[string]*entry
 	running int
+	status  Status
 
 	semaphore chan struct{}
 	strategy  Strategy
 	logger    TelemetryHandler
 
 	wg           sync.WaitGroup
-	isClosed     bool
 	shutdownOnce sync.Once
 	shutdownDone chan struct{}
 }
@@ -51,6 +76,7 @@ type entry struct {
 func NewManager(opts ...Option) *Manager {
 	m := &Manager{
 		pending:      make(map[string]*entry),
+		status:       StatusAccepting,
 		logger:       nopLogger{},
 		shutdownDone: make(chan struct{}),
 	}
@@ -62,12 +88,12 @@ func NewManager(opts ...Option) *Manager {
 
 // Schedule plans a task for execution after duration d.
 // If a task with the same id already exists, the previous one is cancelled
-// and replaced (debouncing). If the manager is closed, Schedule does nothing.
+// and replaced (debouncing). If the manager is not accepting new tasks, Schedule does nothing.
 func (m *Manager) Schedule(id string, d time.Duration, task Task) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if m.isClosed {
+	if m.isClosed() {
 		return
 	}
 
@@ -89,7 +115,7 @@ func (m *Manager) Schedule(id string, d time.Duration, task Task) {
 		m.mu.RLock()
 		defer m.mu.RUnlock()
 
-		if m.isClosed {
+		if m.isClosed() {
 			cancel()
 			return
 		}
@@ -129,8 +155,12 @@ func (m *Manager) Stats() Stats {
 	return Stats{
 		Pending: pending,
 		Running: m.running,
-		Closed:  m.isClosed,
+		Status:  m.status,
 	}
+}
+
+func (m *Manager) isClosed() bool {
+	return m.status != StatusAccepting
 }
 
 func (m *Manager) acquireSlot(ctx context.Context, id string, e *entry) bool {
@@ -199,7 +229,7 @@ func (m *Manager) Cancel(id string) {
 func (m *Manager) Shutdown(ctx context.Context) error {
 	m.shutdownOnce.Do(func() {
 		m.mu.Lock()
-		m.isClosed = true
+		m.status = StatusDraining
 
 		for id, e := range m.pending {
 			e.timer.Stop()
@@ -211,6 +241,9 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 
 		go func() {
 			m.wg.Wait()
+			m.mu.Lock()
+			m.status = StatusClosed
+			m.mu.Unlock()
 			close(m.shutdownDone)
 		}()
 	})

--- a/pending_test.go
+++ b/pending_test.go
@@ -151,12 +151,18 @@ func TestManager_ShutdownTimeout(t *testing.T) {
 	if err == nil {
 		t.Error("expected timeout error from shutdown, got nil")
 	}
+	if s := mgr.Stats(); s.Status != StatusDraining {
+		t.Fatalf("expected status to be draining after shutdown timeout: %+v", s)
+	}
 
 	close(release)
 	longCtx, longCancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer longCancel()
 	if err := mgr.Shutdown(longCtx); err != nil {
 		t.Fatalf("expected shutdown to eventually complete after release: %v", err)
+	}
+	if s := mgr.Stats(); s.Status != StatusClosed {
+		t.Fatalf("expected status to be closed after shutdown completion: %+v", s)
 	}
 }
 
@@ -253,19 +259,19 @@ func TestManager_StatsSnapshotLifecycle(t *testing.T) {
 	mgr := NewManager()
 
 	s := mgr.Stats()
-	if s.Pending != 0 || s.Running != 0 || s.Closed {
+	if s.Pending != 0 || s.Running != 0 || s.Status != StatusAccepting {
 		t.Fatalf("unexpected initial stats: %+v", s)
 	}
 
 	mgr.Schedule("stats-pending", time.Hour, func(ctx context.Context) {})
 	s = mgr.Stats()
-	if s.Pending != 1 || s.Running != 0 || s.Closed {
+	if s.Pending != 1 || s.Running != 0 || s.Status != StatusAccepting {
 		t.Fatalf("unexpected stats after schedule: %+v", s)
 	}
 
 	mgr.Cancel("stats-pending")
 	s = mgr.Stats()
-	if s.Pending != 0 || s.Running != 0 || s.Closed {
+	if s.Pending != 0 || s.Running != 0 || s.Status != StatusAccepting {
 		t.Fatalf("unexpected stats after cancel: %+v", s)
 	}
 
@@ -274,7 +280,7 @@ func TestManager_StatsSnapshotLifecycle(t *testing.T) {
 	}
 
 	s = mgr.Stats()
-	if s.Pending != 0 || s.Running != 0 || !s.Closed {
+	if s.Pending != 0 || s.Running != 0 || s.Status != StatusClosed {
 		t.Fatalf("unexpected stats after shutdown: %+v", s)
 	}
 }
@@ -300,7 +306,7 @@ func TestManager_StatsPendingAndRunning(t *testing.T) {
 
 	waitFor(t, 200*time.Millisecond, func() bool {
 		s := mgr.Stats()
-		return s.Running == 1 && s.Pending == 1 && !s.Closed
+		return s.Running == 1 && s.Pending == 1 && s.Status == StatusAccepting
 	}, "expected one running and one pending task")
 
 	select {
@@ -345,6 +351,9 @@ func TestManager_StatsPendingClampWhenCanceledWhileRunning(t *testing.T) {
 	}
 	if s.Pending != 0 {
 		t.Fatalf("expected pending to clamp to zero, got %+v", s)
+	}
+	if s.Status != StatusAccepting {
+		t.Fatalf("expected status to remain accepting while task runs: %+v", s)
 	}
 
 	close(release)
@@ -406,6 +415,27 @@ func TestManager_StatsConcurrentAccess(t *testing.T) {
 	}
 }
 
+func TestStatus_String(t *testing.T) {
+	tests := []struct {
+		name   string
+		status Status
+		want   string
+	}{
+		{name: "accepting", status: StatusAccepting, want: "accepting"},
+		{name: "draining", status: StatusDraining, want: "draining"},
+		{name: "closed", status: StatusClosed, want: "closed"},
+		{name: "unknown", status: Status(99), want: "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.status.String(); got != tt.want {
+				t.Fatalf("unexpected status string for %v: got %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
 func waitFor(t *testing.T, timeout time.Duration, cond func() bool, msg string) {
 	t.Helper()
 
@@ -448,7 +478,7 @@ func TestCoverage_TimerRaceGuard(t *testing.T) {
 	})
 
 	mgr.mu.Lock()
-	mgr.isClosed = true
+	mgr.status = StatusDraining
 	mgr.mu.Unlock()
 
 	select {


### PR DESCRIPTION
Summary
- replace Stats.Closed with Stats.Status
- add lifecycle states: StatusAccepting, StatusDraining, StatusClosed
- make shutdown transitions explicit: Accepting -> Draining -> Closed
- add Status.String() and update tests/docs/changelog

Breaking change
Stats.Closed has been removed in favor of Stats.Status.

Validation
- go test ./...
- go test -race ./...
- go test -covermode=atomic -coverprofile=coverage.out ./... (100.0%)

Closes #11