### PR TITLE
chore: prepare v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on https://keepachangelog.com/en/1.1.0/, and this project fo
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-03-05
+
 ### Added
 - `IsPending(id)` helper to check whether a task exists and has not started.
 - `TimeRemaining(id)` helper to inspect remaining time until a task timer fires.


### PR DESCRIPTION
## Summary
- cut changelog entries from Unreleased into 0.3.0 (2026-03-05)

## Notes
- release-prep metadata only (no code changes)