### PR TITLE
chore: modernize loops and pending clamp with Go 1.25 syntax

### DIFF
--- a/pending.go
+++ b/pending.go
@@ -94,10 +94,7 @@ func (m *Manager) Stats() Stats {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	pending := len(m.pending) - m.running
-	if pending < 0 {
-		pending = 0
-	}
+	pending := max(len(m.pending)-m.running, 0)
 
 	return Stats{
 		Pending: pending,

--- a/pending_benchmark_test.go
+++ b/pending_benchmark_test.go
@@ -59,7 +59,7 @@ func BenchmarkManager_Shutdown_NoRunningTasks(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		mgr := NewManager()
-		for j := 0; j < pendingTasks; j++ {
+		for j := range pendingTasks {
 			mgr.Schedule(strconv.Itoa(i*pendingTasks+j), time.Hour, benchmarkTask)
 		}
 
@@ -77,7 +77,7 @@ func BenchmarkManager_Shutdown_WithRunningTasks(b *testing.B) {
 		mgr := NewManager(WithLimit(runningTasks, StrategyBlock))
 		started := make(chan struct{}, runningTasks)
 
-		for j := 0; j < runningTasks; j++ {
+		for j := range runningTasks {
 			id := strconv.Itoa(j)
 			mgr.Schedule(id, 0, func(ctx context.Context) {
 				started <- struct{}{}
@@ -85,7 +85,7 @@ func BenchmarkManager_Shutdown_WithRunningTasks(b *testing.B) {
 			})
 		}
 
-		for j := 0; j < runningTasks; j++ {
+		for range runningTasks {
 			select {
 			case <-started:
 			case <-time.After(time.Second):
@@ -98,4 +98,3 @@ func BenchmarkManager_Shutdown_WithRunningTasks(b *testing.B) {
 		b.StopTimer()
 	}
 }
-

--- a/pending_test.go
+++ b/pending_test.go
@@ -376,10 +376,8 @@ func TestManager_StatsConcurrentAccess(t *testing.T) {
 
 	var readers sync.WaitGroup
 	errs := make(chan error, 1)
-	for i := 0; i < 4; i++ {
-		readers.Add(1)
-		go func() {
-			defer readers.Done()
+	for range 4 {
+		readers.Go(func() {
 			for {
 				select {
 				case <-ctx.Done():
@@ -396,10 +394,10 @@ func TestManager_StatsConcurrentAccess(t *testing.T) {
 					return
 				}
 			}
-		}()
+		})
 	}
 
-	for i := 0; i < 200; i++ {
+	for i := range 200 {
 		id := fmt.Sprintf("stats-concurrent-%d", i)
 		mgr.Schedule(id, time.Hour, func(ctx context.Context) {})
 		mgr.Cancel(id)


### PR DESCRIPTION
## Summary
- use built-in max() in Stats() to clamp pending count
- modernize range loops in tests/benchmarks (range over int)
- use WaitGroup.Go in concurrent stats test

## Validation
- go test ./...
- go test -race ./...