### PR TITLE
docs: add simple vs advanced scheduling examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,52 @@ mgr.Schedule("user:42:email", 2*time.Second, func(ctx context.Context) {
 })
 ```
 
+## Scheduling APIs
+
+### Simple path: `Schedule`
+
+Use `Schedule` for straightforward delayed execution with ID-based debouncing:
+
+```go
+mgr.Schedule("invoice:42:reminder", 10*time.Minute, func(ctx context.Context) {
+    if ctx.Err() != nil {
+        return
+    }
+    sendReminder("42")
+})
+```
+
+### Advanced path: `ScheduleWith`
+
+Use `ScheduleWith` when you need option-driven behavior such as absolute-time
+scheduling and `IfAbsent` semantics:
+
+```go
+at := time.Now().Add(30 * time.Second)
+
+scheduled, err := mgr.ScheduleWith(
+    "report:nightly",
+    func(ctx context.Context) error {
+        return generateReport(ctx)
+    },
+    pending.ScheduleOptions{
+        At:       at,
+        IfAbsent: true,
+    },
+)
+if err != nil {
+    if errors.Is(err, pending.ErrInvalidScheduleOptions) {
+        log.Printf("invalid scheduling options: %v", err)
+    }
+    if errors.Is(err, pending.ErrManagerNotAccepting) {
+        log.Printf("manager is shutting down, task rejected")
+    }
+}
+if !scheduled {
+    log.Printf("task already exists and IfAbsent prevented replacement")
+}
+```
+
 ## Cookbook
 
 ### Debouncing User Events

--- a/doc.go
+++ b/doc.go
@@ -4,6 +4,10 @@
 // task (debouncing). The manager supports cancellation, graceful shutdown, and
 // optional concurrency limits with block or drop strategies.
 //
+// Use Schedule for the simple delayed-execution path, and ScheduleWith with
+// ScheduleOptions for advanced behavior such as absolute-time scheduling and
+// non-replacing IfAbsent semantics.
+//
 // Runtime state can be inspected with Stats(), while IsPending() and
 // TimeRemaining() provide per-task introspection.
 package pending


### PR DESCRIPTION
## Summary
- add README section documenting simple `Schedule` vs advanced `ScheduleWith`
- include `ScheduleWith` example with `At` + `IfAbsent` behavior and error handling
- update package docs to call out both scheduling paths

## Validation
- go test ./...

Closes #30
