### PR TITLE
feat: add SkipIfRunning schedule option

### DIFF
--- a/pending.go
+++ b/pending.go
@@ -172,6 +172,9 @@ func (m *Manager) schedule(id string, task TaskWithError, cfg scheduleConfig) (s
 		if cfg.ifAbsent {
 			return false, nil
 		}
+		if cfg.skipIfRunning && old.started.Load() {
+			return false, nil
+		}
 		old.timer.Stop()
 		old.cancel()
 		m.logger.OnRescheduled(id)

--- a/pending_test.go
+++ b/pending_test.go
@@ -382,6 +382,77 @@ func TestManager_ScheduleWith_IfAbsentDoesNotReplace(t *testing.T) {
 	}
 }
 
+func TestManager_ScheduleWith_SkipIfRunningDoesNotQueue(t *testing.T) {
+	mgr := NewManager()
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondRan := make(chan struct{}, 1)
+
+	scheduled, err := mgr.ScheduleWith("same-id", func(ctx context.Context) error {
+		close(firstStarted)
+		<-releaseFirst
+		return nil
+	}, ScheduleOptions{Delay: 0})
+	if err != nil || !scheduled {
+		t.Fatalf("expected first schedule to succeed: scheduled=%v err=%v", scheduled, err)
+	}
+
+	<-firstStarted
+
+	scheduled, err = mgr.ScheduleWith("same-id", func(ctx context.Context) error {
+		secondRan <- struct{}{}
+		return nil
+	}, ScheduleOptions{Delay: 0, SkipIfRunning: true})
+	if err != nil {
+		t.Fatalf("expected no error for SkipIfRunning path, got %v", err)
+	}
+	if scheduled {
+		t.Fatal("expected schedule to be skipped while matching task is running")
+	}
+
+	close(releaseFirst)
+
+	select {
+	case <-secondRan:
+		t.Fatal("task should not have been queued while previous run was active")
+	case <-time.After(80 * time.Millisecond):
+	}
+}
+
+func TestManager_ScheduleWith_SkipIfRunningStillReplacesPending(t *testing.T) {
+	mgr := NewManager()
+	firstRan := make(chan struct{}, 1)
+	secondRan := make(chan struct{}, 1)
+
+	scheduled, err := mgr.ScheduleWith("same-id", func(ctx context.Context) error {
+		firstRan <- struct{}{}
+		return nil
+	}, ScheduleOptions{Delay: 80 * time.Millisecond})
+	if err != nil || !scheduled {
+		t.Fatalf("expected first schedule to succeed: scheduled=%v err=%v", scheduled, err)
+	}
+
+	scheduled, err = mgr.ScheduleWith("same-id", func(ctx context.Context) error {
+		secondRan <- struct{}{}
+		return nil
+	}, ScheduleOptions{Delay: 0, SkipIfRunning: true})
+	if err != nil || !scheduled {
+		t.Fatalf("expected pending task to be replaced: scheduled=%v err=%v", scheduled, err)
+	}
+
+	select {
+	case <-secondRan:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected replacement task to run")
+	}
+
+	select {
+	case <-firstRan:
+		t.Fatal("expected original pending task to be replaced")
+	case <-time.After(120 * time.Millisecond):
+	}
+}
+
 func TestManager_ScheduleWith_TaskErrorReported(t *testing.T) {
 	wantErr := errors.New("boom")
 	spy := &spyLogger{failedSig: make(chan struct{}, 1)}

--- a/schedule.go
+++ b/schedule.go
@@ -17,6 +17,8 @@ type ScheduleOptions struct {
 	At time.Time
 	// IfAbsent only schedules when no task with the same ID exists.
 	IfAbsent bool
+	// SkipIfRunning skips scheduling when a task with the same ID is already executing.
+	SkipIfRunning bool
 	// Group is reserved for future grouped task operations.
 	Group string
 	// Retry is reserved for future retry support.
@@ -33,8 +35,9 @@ type RetryPolicy struct {
 }
 
 type scheduleConfig struct {
-	delay    time.Duration
-	ifAbsent bool
+	delay         time.Duration
+	ifAbsent      bool
+	skipIfRunning bool
 }
 
 func newConfig() scheduleConfig {
@@ -43,6 +46,7 @@ func newConfig() scheduleConfig {
 
 func (c scheduleConfig) validate(opt ScheduleOptions) (scheduleConfig, error) {
 	c.ifAbsent = opt.IfAbsent
+	c.skipIfRunning = opt.SkipIfRunning
 
 	hasDelay := opt.Delay != 0
 	hasAt := !opt.At.IsZero()


### PR DESCRIPTION
## Summary
- add `SkipIfRunning` to `ScheduleOptions`
- skip scheduling when the same task ID is already running
- keep existing pending-task replacement behavior unchanged
- add tests for running vs pending semantics

## Validation
- `go test ./...`
- `go test -race ./...`
- `go test -cover ./...`
