### PR TITLE
feat: add OnExecuting telemetry hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on https://keepachangelog.com/en/1.1.0/, and this project fo
 
 ## [Unreleased]
 
+### Added
+- `TelemetryHandler.OnExecuting(id)` hook, emitted immediately before a task begins executing.
+
+### Changed
+- `TelemetryHandler` implementers will need to add `OnExecuting(id)` in the next release. This is a breaking API change and should ship as `v0.5.0`.
+
 ## [0.4.0] - 2026-04-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -93,6 +93,21 @@ if !scheduled {
 }
 ```
 
+## Telemetry
+
+`TelemetryHandler` can observe the task lifecycle through these hooks:
+
+- `OnScheduled` when a task is first accepted.
+- `OnRescheduled` when a pending task with the same ID is replaced.
+- `OnExecuting` immediately before the task function is invoked.
+- `OnExecuted` after the task returns, with execution duration.
+- `OnCancelled` when a pending task is canceled or removed during shutdown.
+- `OnFailed` when a task returns an error, or when `StrategyDrop` rejects execution.
+
+Adding `OnExecuting` expands the `TelemetryHandler` interface. Existing custom
+implementations will need to add that method when upgrading to the next
+release.
+
 ## Cookbook
 
 ### Debouncing User Events

--- a/example_test.go
+++ b/example_test.go
@@ -10,6 +10,7 @@ type exampleTelemetry struct{}
 
 func (exampleTelemetry) OnScheduled(id string, d time.Duration)       {}
 func (exampleTelemetry) OnRescheduled(id string)                      {}
+func (exampleTelemetry) OnExecuting(id string)                        {}
 func (exampleTelemetry) OnExecuted(id string, duration time.Duration) {}
 func (exampleTelemetry) OnCancelled(id string)                        {}
 func (exampleTelemetry) OnFailed(id string, err error) {

--- a/pending.go
+++ b/pending.go
@@ -208,6 +208,7 @@ func (m *Manager) schedule(id string, task TaskWithError, cfg scheduleConfig) (s
 			m.running.Add(1)
 			defer m.running.Add(-1)
 
+			m.logger.OnExecuting(id)
 			start := time.Now()
 			err := task(ctx)
 			duration := time.Since(start)

--- a/pending_test.go
+++ b/pending_test.go
@@ -14,6 +14,7 @@ type spyLogger struct {
 	mu        sync.Mutex
 	dropped   bool
 	failedSig chan struct{}
+	executing chan struct{}
 }
 
 func (s *spyLogger) OnFailed(id string, err error) {
@@ -23,6 +24,15 @@ func (s *spyLogger) OnFailed(id string, err error) {
 	if s.failedSig != nil {
 		select {
 		case s.failedSig <- struct{}{}:
+		default:
+		}
+	}
+}
+
+func (s *spyLogger) OnExecuting(id string) {
+	if s.executing != nil {
+		select {
+		case s.executing <- struct{}{}:
 		default:
 		}
 	}
@@ -469,6 +479,24 @@ func TestManager_ScheduleWith_TaskErrorReported(t *testing.T) {
 	case <-spy.failedSig:
 	case <-time.After(200 * time.Millisecond):
 		t.Fatal("expected OnFailed to be called for task error")
+	}
+}
+
+func TestManager_ScheduleWith_ReportsOnExecuting(t *testing.T) {
+	spy := &spyLogger{executing: make(chan struct{}, 1)}
+	mgr := NewManager(WithLogger(spy))
+
+	scheduled, err := mgr.ScheduleWith("exec-hook", func(ctx context.Context) error {
+		return nil
+	}, ScheduleOptions{Delay: 0})
+	if err != nil || !scheduled {
+		t.Fatalf("expected schedule to succeed: scheduled=%v err=%v", scheduled, err)
+	}
+
+	select {
+	case <-spy.executing:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected OnExecuting to be called before task execution")
 	}
 }
 

--- a/pending_test.go
+++ b/pending_test.go
@@ -802,6 +802,7 @@ func TestCoverageBooster(t *testing.T) {
 	n := nopLogger{}
 	n.OnScheduled("t", time.Second)
 	n.OnRescheduled("t")
+	n.OnExecuting("t")
 	n.OnExecuted("t", time.Second)
 	n.OnCancelled("t")
 	n.OnFailed("t", fmt.Errorf("err"))

--- a/telemetry.go
+++ b/telemetry.go
@@ -8,6 +8,7 @@ import "time"
 type TelemetryHandler interface {
 	OnScheduled(id string, d time.Duration)
 	OnRescheduled(id string)
+	OnExecuting(id string)
 	OnExecuted(id string, duration time.Duration)
 	OnCancelled(id string)
 	OnFailed(id string, err error)
@@ -17,6 +18,7 @@ type nopLogger struct{}
 
 func (n nopLogger) OnScheduled(id string, d time.Duration)  {}
 func (n nopLogger) OnRescheduled(id string)                 {}
+func (n nopLogger) OnExecuting(id string)                   {}
 func (n nopLogger) OnExecuted(id string, dur time.Duration) {}
 func (n nopLogger) OnCancelled(id string)                   {}
 func (n nopLogger) OnFailed(id string, err error)           {}


### PR DESCRIPTION
## Summary
- add `TelemetryHandler.OnExecuting(id)` and emit it immediately before task execution
- update docs and examples to describe the new telemetry hook
- add a real test covering `OnExecuting`

## Release note
- this expands the public `TelemetryHandler` interface and should ship as a breaking change in the next release (`v0.5.0`)

## Validation
- `go test ./...`
- `go test -race ./...`
- `go test -cover ./...`
