### PR TITLE
chore: prepare v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ The format is based on https://keepachangelog.com/en/1.1.0/, and this project fo
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-19
+
 ### Added
 - `TelemetryHandler.OnExecuting(id)` hook, emitted immediately before a task begins executing.
 
 ### Changed
-- `TelemetryHandler` implementers will need to add `OnExecuting(id)` in the next release. This is a breaking API change and should ship as `v0.5.0`.
+- `TelemetryHandler` implementers must add `OnExecuting(id)`. This is a breaking API change.
 
 ## [0.4.0] - 2026-04-10
 


### PR DESCRIPTION
## Summary
- cut the changelog for `v0.5.0`

## Validation
- `go test ./...`
- `go test -race ./...`
- `go test -cover ./...`
